### PR TITLE
Use core-js polyfill for Object.entries

### DIFF
--- a/lib/general.js
+++ b/lib/general.js
@@ -1,4 +1,5 @@
 import coreIncludes from 'core-js/library/fn/array/includes';
+import coreObjectEntries from 'core-js/library/fn/object/entries';
 
 
 /**
@@ -229,7 +230,7 @@ function applyFilterOnObject(obj, filterFn) {
     }
 
     const filteredObj = {};
-    Object.entries(obj).forEach(([key, val]) => {
+    coreObjectEntries(obj).forEach(([key, val]) => {
         if (filterFn(val, key)) {
             filteredObj[key] = val;
         }

--- a/lib/url.js
+++ b/lib/url.js
@@ -1,3 +1,5 @@
+import coreObjectEntries from 'core-js/library/fn/object/entries';
+
 import camelcase from 'camelcase';
 import decamelize from 'decamelize';
 import queryString from 'query-string';
@@ -48,12 +50,10 @@ export function stringifyObjToQueryParam(obj, transform = decamelize) {
         return '';
     }
 
-    const transformedKeysObj = Object
-        .entries(obj)
-        .reduce((paramsObj, [key, value]) => {
-            paramsObj[transform(key)] = value;
-            return paramsObj;
-        }, {});
+    const transformedKeysObj = coreObjectEntries(obj).reduce((paramsObj, [key, value]) => {
+        paramsObj[transform(key)] = value;
+        return paramsObj;
+    }, {});
 
     return `?${queryString.stringify(transformedKeysObj)}`;
 }
@@ -87,10 +87,8 @@ export function parseQueryParamStrToObj(queryParamString, transform = camelcase)
     const extractedParamString = queryString.extract(queryParamString);
     const parsedObj = queryString.parse(extractedParamString);
 
-    return Object
-        .entries(parsedObj)
-        .reduce((paramsObj, [key, value]) => {
-            paramsObj[transform(key)] = value;
-            return paramsObj;
-        }, {});
+    return coreObjectEntries(parsedObj).reduce((paramsObj, [key, value]) => {
+        paramsObj[transform(key)] = value;
+        return paramsObj;
+    }, {});
 }


### PR DESCRIPTION
Fixes error on attempts to use `Object.entries`.
