### PR TITLE
Enhance formatText for '${...}' formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,5 +66,12 @@
     "shallow-equals": "0.0.0",
     "sprintf-js": "^1.0.3",
     "whatwg-fetch": "^1.0.0"
-  }
+  },
+  "keywords": [
+      "fetch",
+      "module",
+      "request",
+      "util",
+      "utils"
+  ]
 }

--- a/src/request.js
+++ b/src/request.js
@@ -64,8 +64,9 @@ export default function request(url, { jsonBody, query, urlTemplateSpec, ...fetc
 
     return fetch(expandedUrl, fetchConfig)
         .then((res) => {
-            // If status is not a 2xx, assume it's an error
-            if (!(res.status >= 200 && res.status <= 300)) {
+            // If status is not a 2xx (based on Response.ok), assume it's an error
+            // See https://developer.mozilla.org/en-US/docs/Web/API/GlobalFetch/fetch
+            if (!(res && res.ok)) {
                 throw res;
             }
             return res;

--- a/src/request.js
+++ b/src/request.js
@@ -1,4 +1,6 @@
-import { sprintf, vsprint } from 'sprintf-js';
+import { vsprintf } from 'sprintf-js';
+
+import formatText from './text/format_text';
 
 import stringifyAsQueryParam from './url/stringify_as_query_param';
 
@@ -38,7 +40,7 @@ export default function request(url, { jsonBody, query, urlTemplateSpec, ...fetc
         } else if (urlTemplateSpec &&
                    typeof urlTemplateSpec === 'object' &&
                    Object.keys(urlTemplateSpec).length) {
-            expandedUrl = sprintf(url, urlTemplateSpec);
+            expandedUrl = formatText(url, urlTemplateSpec);
         } else if (process.env.NODE_ENV !== 'production') {
             // eslint-disable-next-line no-console
             console.warn('Supplied urlTemplateSpec was not an array or object. Ignoring...');

--- a/src/text/format_text.js
+++ b/src/text/format_text.js
@@ -1,9 +1,95 @@
 import { sprintf } from 'sprintf-js';
 
 
+// Regexes taken from or inspired by sprintf-js
+const Regex = {
+    TEMPLATE_LITERAL: /\${([^\)]+)}/g,
+    KEY: /^([a-z_][a-z_\d]*)/i,
+    KEY_ACCESS: /^\.([a-z_][a-z_\d]*)/i,
+    INDEX_ACCESS: /^\[(\d+)\]/
+};
+
 /**
- * Formats strings similarly to C's sprintf
- * Re-export of sprintf from sprintf-js
- * See https://github.com/alexei/sprintf.js for documentation on usage
+ * Formats strings similarly to C's sprintf, with the addition of '${...}' formats.
+ *
+ * Makes a first pass replacing '${...}' formats before passing the expanded string and other
+ * arguments to sprintf-js. For more information on what sprintf can do, see
+ * https://github.com/alexei/sprintf.js.
+ *
+ * Examples:
+ *   formatText('Hi there ${dimi}!', { dimi: 'Dimi' })
+ *       => 'Hi there Dimi!'
+ *
+ *   formatText('${database} is %(status)s', { database: 'BigchainDB', status: 'big' })
+ *       => 'BigchainDB is big'
+ *
+ * Like sprintf-js, string interpolation for keywords and indexes is supported too:
+ *   formatText('Berlin is best known for its ${berlin.topKnownFor[0].name}', {
+ *       berlin: {
+ *           topKnownFor: [{
+ *               name: 'Currywurst'
+ *           }, ...
+ *           ]
+ *       }
+ *   })
+ *       => 'Berlin is best known for its Currywurst'
  */
-export default sprintf;
+export default function formatText(s, ...argv) {
+    let expandedFormatStr = s;
+
+    // Try to replace formats of the form '${...}' if named replacement fields are used
+    if (s && argv.length === 1 && typeof argv[0] === 'object') {
+        const templateSpecObj = argv[0];
+
+        expandedFormatStr = s.replace(Regex.TEMPLATE_LITERAL, (match, replacement) => {
+            let interpolationLeft = replacement;
+
+            /**
+             * Interpolation algorithm inspired by sprintf-js.
+             *
+             * Goes through the replacement string getting the left-most key or index to interpolate
+             * on each pass. `value` at each step holds the last interpolation result, `curMatch` is
+             * the current property match, and `interpolationLeft` is the portion of the replacement
+             * string still to be interpolated.
+             *
+             * It's useful to note that RegExp.exec() returns with an array holding:
+             *   [0]:  Full string matched
+             *   [1+]: Matching groups
+             *
+             * And that in the regexes defined, the first matching group always corresponds to the
+             * property matched.
+             */
+            let value;
+            let curMatch = Regex.KEY.exec(interpolationLeft);
+            if (curMatch !== null) {
+                value = templateSpecObj[curMatch[1]];
+
+                // Assigning in the conditionals here makes the code less bloated
+                /* eslint-disable no-cond-assign */
+                while ((interpolationLeft = interpolationLeft.substring(curMatch[0].length)) &&
+                       value != null) {
+                    if ((curMatch = Regex.KEY_ACCESS.exec(interpolationLeft))) {
+                        value = value[curMatch[1]];
+                    } else if ((curMatch = Regex.INDEX_ACCESS.exec(interpolationLeft))) {
+                        value = value[curMatch[1]];
+                    } else {
+                        break;
+                    }
+                }
+                /* eslint-enable no-cond-assign */
+            }
+
+            // If there's anything left to interpolate by the end then we've failed to interpolate
+            // the entire replacement string.
+            if (interpolationLeft.length) {
+                throw new SyntaxError(
+                    `[formatText] failed to parse named argument key: ${replacement}`
+                );
+            }
+
+            return value;
+        });
+    }
+
+    return sprintf(expandedFormatStr, ...argv);
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,7 +42,8 @@ const PROD_PLUGINS = [
         },
         output: {
             comments: false
-        }
+        },
+        sourceMap: true
     }),
     new webpack.LoaderOptionsPlugin({
         debug: false,


### PR DESCRIPTION
Improves `formatText`, so that it can handle format strings with `${...}` blocks. This means that `request` can now also handle such strings.
